### PR TITLE
Finish migrating to C# 10.0 and cleanup

### DIFF
--- a/IntelliTect.Multitool.Tests/ClaimsPrincipalGetRolesTests.cs
+++ b/IntelliTect.Multitool.Tests/ClaimsPrincipalGetRolesTests.cs
@@ -1,35 +1,33 @@
-﻿using System;
+﻿using IntelliTect.Multitool.Security;
 using System.Security.Claims;
 using System.Security.Principal;
-using IntelliTect.Multitool.Security;
 using Xunit;
 
-namespace IntelliTect.Multitool.Tests
+namespace IntelliTect.Multitool.Tests;
+
+public class ClaimsPrincipalGetRolesTests
 {
-    public class ClaimsPrincipalGetRolesTests
+    [Fact]
+    public void WhenClaimsPrincipalNull_Should_Throw()
     {
-        [Fact]
-        public void WhenClaimsPrincipalNull_Should_Throw()
-        {
-            ClaimsPrincipal? sut = null;
+        ClaimsPrincipal? sut = null;
 
-            Assert.Throws<ArgumentNullException>(() => sut!.GetRoles());
-        }
+        Assert.Throws<ArgumentNullException>(() => sut!.GetRoles());
+    }
 
-        [Fact]
-        public void WhenClaimsPrincipalHasNoRoles_Should_ReturnEmpty()
-        {
-            ClaimsPrincipal sut = new ClaimsPrincipal();
+    [Fact]
+    public void WhenClaimsPrincipalHasNoRoles_Should_ReturnEmpty()
+    {
+        ClaimsPrincipal sut = new();
 
-            Assert.Empty(sut.GetRoles());
-        }
+        Assert.Empty(sut.GetRoles());
+    }
 
-        [Fact]
-        public void WhenClaimsPrincipalHasRoles_Should_ReturnNotEmpty()
-        {
-            ClaimsPrincipal sut = new GenericPrincipal(new GenericIdentity("Uncle Festus"), new[] {"Foo", "Bar"});
+    [Fact]
+    public void WhenClaimsPrincipalHasRoles_Should_ReturnNotEmpty()
+    {
+        ClaimsPrincipal sut = new GenericPrincipal(new GenericIdentity("Uncle Festus"), new[] { "Foo", "Bar" });
 
-            Assert.Collection(sut.GetRoles(), s => Assert.Equal("Foo", s), t => Assert.Equal("Bar", t) );
-        }
+        Assert.Collection(sut.GetRoles(), s => Assert.Equal("Foo", s), t => Assert.Equal("Bar", t));
     }
 }

--- a/IntelliTect.Multitool.Tests/ClaimsPrincipalGetUserIdTests.cs
+++ b/IntelliTect.Multitool.Tests/ClaimsPrincipalGetUserIdTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using IntelliTect.Multitool.Security;
 using System.Security.Claims;
 using System.Security.Principal;
-using IntelliTect.Multitool.Security;
 using Xunit;
 
 namespace IntelliTect.Multitool.Tests;
@@ -19,7 +18,7 @@ public class ClaimsPrincipalGetUserIdTests
     [Fact]
     public void WhenClaimsPrincipalHasNoProperty_Should_ReturnNull()
     {
-        ClaimsPrincipal sut = new ClaimsPrincipal();
+        ClaimsPrincipal sut = new();
 
         Assert.Null(sut.GetUserId());
     }
@@ -27,7 +26,7 @@ public class ClaimsPrincipalGetUserIdTests
     [Fact]
     public void WhenClaimsPrincipalHasId_Should_ReturnString()
     {
-        ClaimsPrincipal sut = new GenericPrincipal(new GenericIdentity("Taki The Frog"), new []{ "Bar" } );
+        ClaimsPrincipal sut = new GenericPrincipal(new GenericIdentity("Taki The Frog"), new[] { "Bar" });
 
         Assert.Equal("Taki The Frog", sut.GetUserId());
     }

--- a/IntelliTect.Multitool.Tests/IntelliTect.Multitool.Tests.csproj
+++ b/IntelliTect.Multitool.Tests/IntelliTect.Multitool.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/IntelliTect.Multitool.Tests/RepositoryPaths.Tests.cs
+++ b/IntelliTect.Multitool.Tests/RepositoryPaths.Tests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Security.Claims;
-using System.Security.Principal;
-using Xunit;
+﻿using Xunit;
 
 namespace IntelliTect.Multitool.Tests;
 

--- a/IntelliTect.Multitool/AssemblyInfo.cs
+++ b/IntelliTect.Multitool/AssemblyInfo.cs
@@ -1,55 +1,52 @@
-﻿using System;
-using System.IO;
-using System.Reflection;
+﻿using System.Reflection;
 
-namespace IntelliTect.Multitool
+namespace IntelliTect.Multitool;
+
+/// <summary>
+/// Information about the executing assembly.
+/// </summary>
+public static class AssemblyInfo
 {
+    private static DateTime? _Date;
+
     /// <summary>
-    /// Information about the executing assembly.
+    /// Gets the linker date from the assembly header.
     /// </summary>
-    public static class AssemblyInfo
+    public static DateTime Date
     {
-        private static DateTime? _Date;
-
-        /// <summary>
-        /// Gets the linker date from the assembly header.
-        /// </summary>
-        public static DateTime Date
+        get
         {
-            get
+            if (_Date == null)
             {
-                if (_Date == null)
-                {
-                    _Date = GetLinkerTime(Assembly.GetExecutingAssembly());
-                }
-                return _Date.Value;
+                _Date = GetLinkerTime(Assembly.GetExecutingAssembly());
             }
+            return _Date.Value;
         }
+    }
 
-        /// <summary>
-        /// Gets the linker date of the assembly.
-        /// </summary>
-        /// <param name="assembly"></param>
-        /// <returns></returns>
-        /// <remarks>https://blog.codinghorror.com/determining-build-date-the-hard-way/</remarks>
-        private static DateTime GetLinkerTime(Assembly assembly)
-        {
-            var filePath = assembly.Location;
-            const int cPeHeaderOffset = 60;
-            const int cLinkerTimestampOffset = 8;
+    /// <summary>
+    /// Gets the linker date of the assembly.
+    /// </summary>
+    /// <param name="assembly"></param>
+    /// <returns></returns>
+    /// <remarks>https://blog.codinghorror.com/determining-build-date-the-hard-way/</remarks>
+    private static DateTime GetLinkerTime(Assembly assembly)
+    {
+        var filePath = assembly.Location;
+        const int cPeHeaderOffset = 60;
+        const int cLinkerTimestampOffset = 8;
 
-            var buffer = new byte[2048];
+        var buffer = new byte[2048];
 
-            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
-                stream.Read(buffer, 0, 2048);
+        using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            stream.Read(buffer, 0, 2048);
 
-            var offset = BitConverter.ToInt32(buffer, cPeHeaderOffset);
-            var secondsSince1970 = BitConverter.ToInt32(buffer, offset + cLinkerTimestampOffset);
-            var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var offset = BitConverter.ToInt32(buffer, cPeHeaderOffset);
+        var secondsSince1970 = BitConverter.ToInt32(buffer, offset + cLinkerTimestampOffset);
+        var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-            var linkTimeUtc = epoch.AddSeconds(secondsSince1970);
+        var linkTimeUtc = epoch.AddSeconds(secondsSince1970);
 
-            return linkTimeUtc;
-        }
+        return linkTimeUtc;
     }
 }

--- a/IntelliTect.Multitool/Properties/AssemblyInfo.cs
+++ b/IntelliTect.Multitool/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 
 [assembly: CLSCompliant(true)]

--- a/IntelliTect.Multitool/Security/ClaimsPrincipalExtensions.cs
+++ b/IntelliTect.Multitool/Security/ClaimsPrincipalExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 
 namespace IntelliTect.Multitool.Security;
 


### PR DESCRIPTION
- Convert to file-scoped namespaces
- Convert to using new(...)
- Remove unnecessary using statements