### PR TITLE
refactor: Move Claims Principal to be under Extensions namespace instead of Security

### DIFF
--- a/IntelliTect.Multitool.Tests/Extensions/ClaimsPrincipalGetRolesTests.cs
+++ b/IntelliTect.Multitool.Tests/Extensions/ClaimsPrincipalGetRolesTests.cs
@@ -1,9 +1,8 @@
-﻿using IntelliTect.Multitool.Security;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Security.Principal;
 using Xunit;
 
-namespace IntelliTect.Multitool.Tests;
+namespace IntelliTect.Multitool.Extensions.Tests;
 
 public class ClaimsPrincipalGetRolesTests
 {

--- a/IntelliTect.Multitool.Tests/Extensions/ClaimsPrincipalGetUserIdTests.cs
+++ b/IntelliTect.Multitool.Tests/Extensions/ClaimsPrincipalGetUserIdTests.cs
@@ -1,9 +1,8 @@
-﻿using IntelliTect.Multitool.Security;
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Security.Principal;
 using Xunit;
 
-namespace IntelliTect.Multitool.Tests;
+namespace IntelliTect.Multitool.Extensions.Tests;
 
 public class ClaimsPrincipalGetUserIdTests
 {

--- a/IntelliTect.Multitool.Tests/ReleaseDateAttribute.Tests.cs
+++ b/IntelliTect.Multitool.Tests/ReleaseDateAttribute.Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Xunit;
+﻿using Xunit;
 
 namespace IntelliTect.Multitool.Tests;
 

--- a/IntelliTect.Multitool/Extensions/ClaimsPrincipalExtensions.cs
+++ b/IntelliTect.Multitool/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Security.Claims;
 
-namespace IntelliTect.Multitool.Security;
+namespace IntelliTect.Multitool.Extensions;
 
 /// <summary>
 /// Gets information from a <see cref="ClaimsPrincipal"/>

--- a/IntelliTect.Multitool/IntelliTect.Multitool.csproj
+++ b/IntelliTect.Multitool/IntelliTect.Multitool.csproj
@@ -24,6 +24,6 @@
 		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
-		<None Include="Build/IntelliTect.Multitool.targets" Pack="true" PackagePath="build\IntelliTect.Multitool.targets"/>
+		<None Include="Build/IntelliTect.Multitool.targets" Pack="true" PackagePath="build\IntelliTect.Multitool.targets" />
 	</ItemGroup>
 </Project>

--- a/IntelliTect.Multitool/ReleaseDateAttribute.cs
+++ b/IntelliTect.Multitool/ReleaseDateAttribute.cs
@@ -33,5 +33,5 @@ public class ReleaseDateAttribute : Attribute
         object[]? attribute = (assembly ?? Assembly.GetEntryAssembly())?.GetCustomAttributes(typeof(ReleaseDateAttribute), false);
         return attribute?.Length >= 1 ? ((ReleaseDateAttribute)attribute[0]).ReleaseDate : null;
     }
-    
+
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   string fullPathToTheFile = Path.Combine(IntelliTect.Multitool.RepositoryPaths.GetDefaultRepoRoot(), "TheFile.txt");
   ```
 
-## Security
+## Extensions
 
 - ClaimsPrincipalExtensions: Extension methods to get a user ID and roles.
 


### PR DESCRIPTION
This is for future extensions so that they are all in the same namespace