### PR TITLE
feat: Add System.Linq WhereNotNull() extension

### DIFF
--- a/IntelliTect.Multitool.sln
+++ b/IntelliTect.Multitool.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\deploy.yml = .github\workflows\deploy.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/IntelliTect.Multitool/Extensions/SystemLinqExtensions.cs
+++ b/IntelliTect.Multitool/Extensions/SystemLinqExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace IntelliTect.Multitool.Extensions;
+
+/// <summary>
+/// Various Linq extensions
+/// </summary>
+public static class SystemLinqExtensions
+{
+    /// <summary>
+    /// Filters a sequence of values to only those that are not null.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of source.</typeparam>
+    /// <param name="source">A <see cref="IEnumerable{T}"/> to filter.</param>
+    /// <returns>An <see cref="IEnumerable{T}"/> that contains elements from the input that are not null.</returns>
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class?
+    {
+        return (IEnumerable<T>)source.Where(item => item is not null);
+    }
+}


### PR DESCRIPTION
This solves the case of `foreach (string folder in folders.Where(x => !string.IsNullOrWhiteSpace(x)))` not working by itself and needing to cast it or similar