### PR TITLE
fix: resolve MSB3491 race condition in WriteLaunchers parallel builds

### DIFF
--- a/IntelliTect.Multitool.AotTest/Program.cs
+++ b/IntelliTect.Multitool.AotTest/Program.cs
@@ -20,7 +20,7 @@ if (!slugOk || !urlOk || !filterOk || !attributeOk)
     return 1;
 }
 
-// RepositoryPaths is excluded: its static initializer reads a build-time temp file
+// RepositoryPaths is excluded: its static initializer reads a build-time file from the output directory
 // that doesn't exist at AOT runtime. The class is AOT-compatible (file I/O + LINQ only).
 
 Console.WriteLine("AOT test passed.");

--- a/IntelliTect.Multitool/Build/IntelliTect.Multitool.targets
+++ b/IntelliTect.Multitool/Build/IntelliTect.Multitool.targets
@@ -24,7 +24,6 @@
 
     <Target Name="WriteLaunchers" AfterTargets="CopyFilesToOutputDirectory">
         <PropertyGroup>
-            <TempStagingPath Condition="'$(TempStagingPath)' == ''">$([System.IO.Path]::GetTempPath())</TempStagingPath>
             <LUTInformation>
                 BuildingForLiveUnitTesting::$(BuildingForLiveUnitTesting)
                 SolutionDir::$(SolutionDir)
@@ -32,7 +31,6 @@
             </LUTInformation>
         </PropertyGroup>
 
-        <WriteLinesToFile File="$(TempStagingPath)\IntelliTect.MultiTool.BuildVariables.tmp" Overwrite="true" Lines="$(LUTInformation)" Condition="'$(SolutionDir)' != ''" />
-        <WriteLinesToFile File="$(TempStagingPath)\IntelliTect.MultiTool.BuildVariables.tmp" Overwrite="true" Lines="$(LUTInformation)" Condition="'$(SolutionDir)' == '' AND !Exists('$(TempStagingPath)\IntelliTect.MultiTool.BuildVariables.tmp')" />
+        <WriteLinesToFile File="$(OutDir)IntelliTect.MultiTool.BuildVariables.tmp" Overwrite="true" Lines="$(LUTInformation)" />
     </Target>
 </Project>

--- a/IntelliTect.Multitool/RepositoryPaths.cs
+++ b/IntelliTect.Multitool/RepositoryPaths.cs
@@ -15,7 +15,7 @@ public static class RepositoryPaths
     /// <summary>
     /// Holds the key value pairs of the build variables that this class can use.
     /// </summary>
-    public static ReadOnlyDictionary<string, string?> BuildVariables { get; } = new(File.ReadAllLines(Path.Combine(Path.GetTempPath(), BuildVariableFileName))
+    public static ReadOnlyDictionary<string, string?> BuildVariables { get; } = new(File.ReadAllLines(Path.Combine(AppContext.BaseDirectory, BuildVariableFileName))
         .Select(line => line.Split("::"))
         .ToDictionary(split => split[0].Trim(),
         split => !string.IsNullOrEmpty(split[1]) ? split[1].Trim() : null));


### PR DESCRIPTION
## Problem

`WriteLaunchers` wrote build variables to a hardcoded global temp path:

```
%TEMP%\IntelliTect.MultiTool.BuildVariables.tmp
```

When a solution has multiple projects referencing this package, `dotnet build` builds them in parallel. All projects resolved to the **same absolute file path**, and `WriteLinesToFile` with `Overwrite="true"` is not atomic (delete-then-create). Two parallel project builds racing on that path caused:

```
error MSB3491: Could not write lines to file "...\IntelliTect.MultiTool.BuildVariables.tmp".
Cannot create a file when that file already exists.
```

There was also a **correctness bug**: even when writes didn't collide, the winning writer was non-deterministic — the file could end up containing variables from any project in the solution, not the one that would consume it at runtime.

## Fix

Write the build variables file to `$(OutDir)` — each project's output directory — which is already unique per project and per TFM. Update the C# reader to look in `AppContext.BaseDirectory` instead of `Path.GetTempPath()`, since `AppContext.BaseDirectory` resolves to the same output directory at runtime.

### Changes

**`IntelliTect.Multitool/Build/IntelliTect.Multitool.targets`**
- Remove the `TempStagingPath` property (was the source of the shared path)
- Collapse two conditional `WriteLinesToFile` calls into one unconditional write to `$(OutDir)IntelliTect.MultiTool.BuildVariables.tmp`

**`IntelliTect.Multitool/RepositoryPaths.cs`**
- `Path.GetTempPath()` → `AppContext.BaseDirectory` in `BuildVariables` initializer

**`IntelliTect.Multitool.AotTest/Program.cs`**
- Update stale comment to reflect the new file location

## Why `$(OutDir)` + `AppContext.BaseDirectory`

| Property | Value |
|---|---|
| Parallel-safe | ✅ Each project has a unique output dir |
| LUT-compatible | ✅ VS LUT shadow-copies the entire output dir; `AppContext.BaseDirectory` follows |
| AOT-safe | ✅ `AppContext.BaseDirectory` works in single-file/AOT (unlike `Assembly.Location`) |
| Cross-platform | ✅ `$(OutDir)` always ends with a path separator; valid on Windows and Linux |
