### PR TITLE
feat(ci): attest nuget release artifacts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,8 @@ jobs:
       url: 'https://www.nuget.org/packages/IntelliTect.Multitool'
     permissions:
       id-token: write     # Required for OIDC token (NuGet trusted publishing)
+      attestations: write # Required for GitHub artifact attestations
+      artifact-metadata: write # Required to create artifact storage records
       contents: write     # Required for softprops/action-gh-release
     steps:
       - name: Download artifact from build job
@@ -68,6 +70,10 @@ jobs:
         run: |
           $tagVersion = "${{ github.ref }}".substring(11)
           echo "TAG_VERSION=$tagVersion" >> $env:GITHUB_OUTPUT
+      - name: Attest NuGet package provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: IntelliTect.Multitool.${{ steps.tag-version.outputs.TAG_VERSION }}.nupkg
       - name: NuGet login
         uses: NuGet/login@v1
         id: login


### PR DESCRIPTION
## Why
We already use OIDC trusted publishing to nuget.org, but release artifacts did not have GitHub-signed provenance metadata. Adding attestation strengthens supply-chain integrity and gives maintainers and consumers a way to verify where the published package came from.

## What changed
- Added `attestations: write` and `artifact-metadata: write` permissions to the `deploy` job in `deploy.yml`.
- Added an `actions/attest@v4` step that attests the built `IntelliTect.Multitool.<tag>.nupkg` before NuGet push and release upload.

## Notes
- This is a minimal workflow-only change. Existing build, test, package, and publish flow remains unchanged.